### PR TITLE
Release v1.2.1: parallel system loading and yield warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,148 @@
 # Galaxy
+
+A small lightweight framework that lets you grab any module from anywhere with `shared("Name")`.
+
+## Features
+
+- Grab any module by name with `shared("Name")`.
+- Server and client code is detected and started for you.
+- Modules load only when first used, then get cached.
+
+## Installation
+
+Add this to your `wally.toml` and run `wally install`:
+
+```toml
+[dependencies]
+Galaxy = "artisticvampyre/galaxy@1.1.0"
+```
+
+## Getting Started
+
+### 1. Start Galaxy
+
+From a server `Script` and a client `LocalScript`, tell Galaxy where to look for your code:
+
+```lua
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Galaxy = require(ReplicatedStorage.Packages.Galaxy)
+
+Galaxy.Launch({
+    -- Where your reusable modules live
+    Modules = { ReplicatedStorage.Packages, ReplicatedStorage.Shared },
+    -- Where your systems live
+    Systems = { script:WaitForChild("systems") },
+})
+```
+
+### 2. Make a system
+
+A system is just a module whose name ends in `Service` (server) or `Controller` (client). Galaxy runs the right ones automatically and calls `onInit` then `onStart`.
+
+```lua
+-- MainService.luau
+local log = shared("log")
+
+local MainService = {}
+
+function MainService:onInit()
+    log.info("MainService initialized")
+end
+
+function MainService:onStart()
+    log.info("MainService started")
+end
+
+return MainService
+```
+
+### 3. Use other modules
+
+Call `shared("Name")` to get any module or system by its name:
+
+```lua
+local MainService = shared("MainService")
+local log = shared("log")
+```
+
+### Tip: autocomplete for `shared(...)`
+
+Because `shared(...)` takes a string, the editor doesn't know the type by itself. Add a `--@module` annotation above the line so the language server treats it as that module and gives you autocomplete:
+
+```lua
+local MainService = shared("MainService") --@module MainService
+```
+
+## How It Works
+
+### Modules and systems
+
+- **Modules** are any `ModuleScript`. They load the first time you ask for them with `shared(...)`.
+- **Systems** are modules named `...Service` or `...Controller`. Galaxy starts them for you when the game launches.
+
+### Server vs. client
+
+Galaxy looks at where the code is running and picks the right systems:
+
+- On the server it runs anything named `Service`.
+- On the client it runs anything named `Controller`.
+
+So you can keep both in the same folder and each side only runs its own.
+
+### When things start
+
+When you call `Galaxy.Launch`:
+
+1. `onInit` is called on every system, one at a time. Use it for setup.
+2. `onStart` is called on every system after all setup is done. Use it for your main logic.
+
+### Loading extra folders into a system
+
+If a system needs helper modules from nearby folders, list them in `DirectoriesToLoad` and Galaxy attaches them for you:
+
+```lua
+local MyService = { DirectoriesToLoad = { "components", "data" } }
+
+function MyService:onInit()
+    -- self.SomeComponent is now available
+end
+
+return MyService
+```
+
+## When Something Goes Wrong
+
+- If a module fails to load, Galaxy warns you and keeps going, so one mistake doesn't break everything.
+- If a module takes too long to load (over 3 seconds), Galaxy tells you which one.
+- If two modules depend on each other in a loop, Galaxy warns you and names them.
+
+## Reference
+
+- `Galaxy.Launch({ Modules = {...}, Systems = {...} })` starts the framework.
+- `shared("Name")` returns a module or system by name. Works anywhere after `Launch`.
+- `Galaxy._VERSION` is the version string.
+- On a system, `onInit(self)` runs first for setup, `onStart(self)` runs after for main logic.
+
+## Project Layout
+
+```
+src/
+  init.luau            the framework
+  CycleMetatable.luau  cyclic dependency helper
+  wally.toml           package info
+test/
+  server/  client/  shared/   example game using Galaxy
+```
+
+## Development
+
+Install tools with [Aftman](https://github.com/LPGhatguy/aftman), then run the test place:
+
+```sh
+aftman install
+rojo serve test.project.json
+```
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your `wally.toml` and run `wally install`:
 
 ```toml
 [dependencies]
-Galaxy = "artisticvampyre/galaxy@1.1.0"
+Galaxy = "artisticvampyre/galaxy@1.2.0"
 ```
 
 ## Getting Started

--- a/src/CycleMetatable.luau
+++ b/src/CycleMetatable.luau
@@ -21,12 +21,7 @@ local METAMETHODS = {
 }
 
 local function formatWarning(self: table, action: string, ...: any): string
-	return string.format(
-		"Detected bare code referencing a cyclic dependency (%s -> %s). Attempt to %s. Please revise.",
-		tostring(CycleMetatable.CurrentModuleLoading),
-		tostring(self.Name),
-		string.format(action, ...)
-	)
+	return `Detected bare code referencing a cyclic dependency ({CycleMetatable.CurrentModuleLoading} -> {self.Name}). Attempt to {action}. Please revise.`
 end
 
 -- Generate metamethods dynamically

--- a/src/init.luau
+++ b/src/init.luau
@@ -28,7 +28,7 @@ type LaunchParams = {
 }
 
 -- 🌟 Main Module
-local Galaxy = { _VERSION = "1.0.1" }
+local Galaxy = { _VERSION = "1.1.0" }
 
 -- 🎯 Environment Detection
 local SystemKey: string = RunService:IsServer() and "service" or "controller"

--- a/src/init.luau
+++ b/src/init.luau
@@ -44,10 +44,6 @@ local Systems: { [ModuleScript]: any?} = {}
 -- Helper Functions
 -----------------------------------------------------
 
-local function _errorHandler(err: any): string
-	return tostring(err) .. "\n" .. debug.traceback()
-end
-
 --[[
 	Requires a module with error isolation + a yield watchdog. require() runs the
 	module's top-level body, which can both error AND yield (e.g. a top-level
@@ -55,17 +51,17 @@ end
 	so we catch errors (returning ok = false) and warn by name if the require
 	yields longer than INIT_YIELD_WARNING_TIME.
 ]]
-local function _safeRequire(module: ModuleScript, label: string): (boolean, any)
+local function _watchYield(label: string, name: string): () -> ()
+	local thread = coroutine.running()
 	local completed = false
 	task.delay(INIT_YIELD_WARNING_TIME, function()
-		if not completed then
-			warn(`⏳[Galaxy][IMPORTANT] requiring {label} {module.Name} has been yielding for {INIT_YIELD_WARNING_TIME}s+. A top-level WaitForChild/:Wait()/yield during require blocks the whole boot, move it into onStart.`)
+		if not completed and coroutine.status(thread) ~= "dead" then
+			warn(`⏳ [Galaxy][IMPORTANT] {label} '{name}' has been yielding for {INIT_YIELD_WARNING_TIME}s+. A top-level WaitForChild/:Wait()/yield blocks the boot; move it into onStart.`)
 		end
 	end)
-
-	local ok, result = xpcall(require, _errorHandler, module)
-	completed = true
-	return ok, result
+	return function()
+		completed = true
+	end
 end
 
 -- Count the number of ancestors for a given instance.
@@ -101,17 +97,14 @@ end
 
 -- Loads the given ModuleScript with error handling. Returns the loaded data.
 local function _load(module: ModuleScript): any?
-	CycleMetatable.CurrentModuleLoading = module.Name
+	local markDone = _watchYield("requiring module", module.Name)
 
-	local success, dataOrErr = _safeRequire(module, "module")
+	CycleMetatable.CurrentModuleLoading = module.Name
+	local data = require(module)
 	CycleMetatable.CurrentModuleLoading = nil
 
-	if success then
-		return dataOrErr
-	end
-
-	warn(`❌ [Galaxy][CRITICAL] Failed to require module {module.Name} (skipped — other modules still load):\n{dataOrErr}`)
-	return nil
+	markDone()
+	return data
 end
 
 -- Adds a ModuleScript to the internal registry, checking for duplicates.
@@ -180,13 +173,9 @@ local function _loadInternal(system, rootModule: ModuleScript)
 				continue
 			end
 
-			local success, dataOrErr = _safeRequire(module, "internal module")
-			if not success then
-				warn(`❌ [Galaxy] Failed to load internal module {module.Name} in system {root.Name} (skipped)! 💥\nError: {dataOrErr}`)
-				continue
-			end
-
+			local markDone = _watchYield("requiring internal module", module.Name)
 			system[module.Name] = require(module)
+			markDone()
 		end
 	end
 end
@@ -203,23 +192,31 @@ local function _indexSystems(location: Instance, systemModules: { ModuleScript }
 	end
 end
 
+local function _awaitThreads(threads: { thread })
+	for _, thread in threads do
+		while coroutine.status(thread) ~= "dead" do
+			task.wait()
+		end
+	end
+end
+
 local function _loadSystems(systemModules: { ModuleScript })
-	local pending = #systemModules
+	local threads: { thread } = {}
 
 	for _, moduleScript: ModuleScript in systemModules do
-		task.spawn(function()
-			local activeSystem = _load(moduleScript)
-			if activeSystem then
-				_loadInternal(activeSystem, moduleScript)
-				Systems[moduleScript] = activeSystem
-			end
-			pending -= 1
-		end)
+		table.insert(
+			threads,
+			task.spawn(function()
+				local activeSystem = _load(moduleScript)
+				if activeSystem then
+					_loadInternal(activeSystem, moduleScript)
+					Systems[moduleScript] = activeSystem
+				end
+			end)
+		)
 	end
 
-	while pending > 0 do
-		task.wait()
-	end
+	_awaitThreads(threads)
 end
 
 -----------------------------------------------------
@@ -283,22 +280,26 @@ function Galaxy.Launch(launchParams: LaunchParams)
 	-- Require every system in parallel and wait for the whole batch before running any lifecycle hooks.
 	_loadSystems(systemModules)
 
+	-- onInit runs for every system in parallel; wait for them all to settle before onStart.
+	local initThreads: { thread } = {}
 	for moduleScript, system in Systems do
 		if typeof(system.onInit) ~= "function" then
 			continue
 		end
 
-		local initThread = task.spawn(function()
-			system.onInit(system)
-		end)
-
-		if coroutine.status(initThread) == "suspended" then
-			warn(
-				`⏳ [Galaxy][IMPORTANT] {moduleScript:GetFullName()}.onInit yielded, continuing without waiting for it. Move WaitForChild / :Wait() / network calls into onStart so init order stays deterministic.`
-			)
-		end
+		local name = moduleScript.Name
+		table.insert(
+			initThreads,
+			task.spawn(function()
+				local markDone = _watchYield("onInit", name)
+				system.onInit(system)
+				markDone()
+			end)
+		)
 	end
+	_awaitThreads(initThreads)
 
+	-- onStart runs only after every onInit has settled.
 	for _, system in Systems do
 		if typeof(system.onStart) ~= "function" then
 			continue

--- a/src/init.luau
+++ b/src/init.luau
@@ -191,22 +191,35 @@ local function _loadInternal(system, rootModule: ModuleScript)
 	end
 end
 
--- Initializes systems by indexing ModuleScripts that match the system key.
-local function _indexSystems(location: Instance)
+-- Collects ModuleScripts that match the system key into systemModules and requires the whole batch in parallel afterwards.
+local function _indexSystems(location: Instance, systemModules: { ModuleScript })
 	for _, descendant: ModuleScript in location:GetDescendants() do
 		if descendant:IsA("ModuleScript") and descendant ~= script then
 			local childIndex = descendant.Name:lower()
 			if childIndex:find(SystemKey) then
-				local activeSystem = _load(descendant)
-				if activeSystem then
-					-- Use the current ModuleScript as the root for internal modules.
-					_loadInternal(activeSystem, descendant)
-					Systems[descendant.Name] = activeSystem
-					-- Rename the module to avoid collisions.
-					descendant.Name = HttpService:GenerateGUID()
-				end
+				table.insert(systemModules, descendant)
 			end
 		end
+	end
+end
+
+local function _loadSystems(systemModules: { ModuleScript })
+	local pending = #systemModules
+
+	for _, moduleScript: ModuleScript in systemModules do
+		task.spawn(function()
+			local activeSystem = _load(moduleScript)
+			if activeSystem then
+				_loadInternal(activeSystem, moduleScript)
+				Systems[moduleScript.Name] = activeSystem
+				moduleScript.Name = HttpService:GenerateGUID()
+			end
+			pending -= 1
+		end)
+	end
+
+	while pending > 0 do
+		task.wait()
 	end
 end
 
@@ -263,9 +276,13 @@ function Galaxy.Launch(launchParams: LaunchParams)
 		_indexModules(moduleRoot)
 	end
 
+	local systemModules: { ModuleScript } = {}
 	for _, systemRoot: Instance in launchParams.Systems do
-		_indexSystems(systemRoot)
+		_indexSystems(systemRoot, systemModules)
 	end
+
+	-- Require every system in parallel and wait for the whole batch before running any lifecycle hooks.
+	_loadSystems(systemModules)
 
 	for name, system in Systems do
 		if typeof(system.onInit) ~= "function" then

--- a/src/init.luau
+++ b/src/init.luau
@@ -8,13 +8,18 @@
     • ⚡ Optimized for performance
     • 🛡️ Type-safe with Luau
     
-    Version: 1.0.0
+    Version: 1.0.1
     Author: ArtisticVampyre
+	Contributor: @32_Bits (https://github.com/git0uttahere)
 --]]
 
 -- 🔧 Core Services
 local HttpService: HttpService = game:GetService("HttpService")
 local RunService: RunService = game:GetService("RunService")
+
+-- ⚙️ Configuration
+-- How long (in seconds) a require/onInit may yield before Galaxy warns about it.
+local INIT_YIELD_WARNING_TIME = 3
 
 -- 📝 Type Definitions
 type LaunchParams = {
@@ -23,7 +28,7 @@ type LaunchParams = {
 }
 
 -- 🌟 Main Module
-local Galaxy = { _VERSION = "1.0.0" }
+local Galaxy = { _VERSION = "1.0.1" }
 
 -- 🎯 Environment Detection
 local SystemKey: string = RunService:IsServer() and "service" or "controller"
@@ -38,6 +43,37 @@ local Systems: { [string]: any } = {}
 -----------------------------------------------------
 -- Helper Functions
 -----------------------------------------------------
+
+local function _errorHandler(err: any): string
+	return tostring(err) .. "\n" .. debug.traceback()
+end
+
+--[[
+	Requires a module with error isolation + a yield watchdog. require() runs the
+	module's top-level body, which can both error AND yield (e.g. a top-level
+	WaitForChild / :Wait()). Either would otherwise silently stall the whole boot,
+	so we catch errors (returning ok = false) and warn by name if the require
+	yields longer than INIT_YIELD_WARNING_TIME.
+]]
+local function _safeRequire(module: ModuleScript, label: string): (boolean, any)
+	local completed = false
+	task.delay(INIT_YIELD_WARNING_TIME, function()
+		if not completed then
+			warn(
+				(`⏳ [Galaxy][IMPORTANT] requiring %s '%s' has been yielding for %ds+. `
+					.. `A top-level WaitForChild/:Wait()/yield during require blocks the whole boot — move it into onInit/onStart.`):format(
+					label,
+					module.Name,
+					INIT_YIELD_WARNING_TIME
+				)
+			)
+		end
+	end)
+
+	local ok, result = xpcall(require, _errorHandler, module)
+	completed = true
+	return ok, result
+end
 
 -- Count the number of ancestors for a given instance.
 local function countAncestors(instance: Instance): number
@@ -74,14 +110,19 @@ end
 local function _load(module: ModuleScript): any?
 	CycleMetatable.CurrentModuleLoading = module.Name
 
-	local success, dataOrErr = pcall(require, module)
+	local success, dataOrErr = _safeRequire(module, "module")
 	CycleMetatable.CurrentModuleLoading = nil
 
 	if success then
 		return dataOrErr
 	end
 
-	warn(("❌ Failed to load module '%s' 💥\nError: %s"):format(module.Name, dataOrErr))
+	warn(
+		(`❌ [Galaxy][CRITICAL] Failed to require module '%s' (skipped — other modules still load):\n%s`):format(
+			module.Name,
+			dataOrErr
+		)
+	)
 	return nil
 end
 
@@ -151,12 +192,14 @@ local function _loadInternal(system, rootModule: ModuleScript)
 				continue
 			end
 
-			local success, dataOrErr = pcall(require, module)
+			local success, dataOrErr = _safeRequire(module, "internal module")
 			if not success then
-				warn("❌ Failed to load internal module '%s' in system '%s'! 💥\nError: %s"):format(
-					module.Name,
-					root.Name,
-					dataOrErr
+				warn(
+					("❌ [Galaxy] Failed to load internal module '%s' in system '%s' (skipped)! 💥\nError: %s"):format(
+						module.Name,
+						root.Name,
+						dataOrErr
+					)
 				)
 				continue
 			end
@@ -242,16 +285,37 @@ function Galaxy.Launch(launchParams: LaunchParams)
 		_indexSystems(systemRoot)
 	end
 
-	for _, system in Systems do
-		if system.onInit and typeof(system.onInit) == "function" then
-			system:onInit()
+	for name, system in Systems do
+		if typeof(system.onInit) ~= "function" then
+			continue
+		end
+
+		local completed = false
+		task.delay(INIT_YIELD_WARNING_TIME, function()
+			if not completed then
+				warn(
+					(`⏳ [Galaxy][IMPORTANT] '%s'.onInit has been yielding for %ds+. `
+						.. `Check for a WaitForChild / :Wait() / network call that never resolves.`):format(
+						name,
+						INIT_YIELD_WARNING_TIME
+					)
+				)
+			end
+		end)
+
+		local ok, err = xpcall(system.onInit, _errorHandler, system)
+		completed = true
+
+		if not ok then
+			error((`[Galaxy] '%s'.onInit errored:\n%s`):format(name, err), 0)
 		end
 	end
 
 	for _, system in Systems do
-		if system.onStart and typeof(system.onStart) == "function" then
-			task.spawn(system.onStart, system)
+		if typeof(system.onStart) ~= "function" then
+			continue
 		end
+		task.spawn(system.onStart, system)
 	end
 end
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -272,24 +272,14 @@ function Galaxy.Launch(launchParams: LaunchParams)
 			continue
 		end
 
-		local completed = false
-		task.delay(INIT_YIELD_WARNING_TIME, function()
-			if not completed then
-				warn(
-					(`⏳ [Galaxy][IMPORTANT] '%s'.onInit has been yielding for %ds+. `
-						.. `Check for a WaitForChild / :Wait() / network call that never resolves.`):format(
-						name,
-						INIT_YIELD_WARNING_TIME
-					)
-				)
-			end
+		local initThread = task.spawn(function()
+			system.onInit(system)
 		end)
 
-		local ok, err = xpcall(system.onInit, _errorHandler, system)
-		completed = true
-
-		if not ok then
-			error((`[Galaxy] '%s'.onInit errored:\n%s`):format(name, err), 0)
+		if coroutine.status(initThread) == "suspended" then
+			warn(
+				`⏳ [Galaxy][IMPORTANT] {name}.onInit yielded, continuing without waiting for it. Move WaitForChild / :Wait() / network calls into onStart so init order stays deterministic.`
+			)
 		end
 	end
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -38,7 +38,7 @@ local CycleMetatable = require(script.CycleMetatable)
 local ModulesLoading: { [ModuleScript]: boolean } = {}
 local LoadedModules: { [ModuleScript]: any } = {}
 local Modules: { [string]: ModuleScript } = {}
-local Systems: { [string]: any } = {}
+local Systems: { [ModuleScript]: any?} = {}
 
 -----------------------------------------------------
 -- Helper Functions
@@ -211,8 +211,7 @@ local function _loadSystems(systemModules: { ModuleScript })
 			local activeSystem = _load(moduleScript)
 			if activeSystem then
 				_loadInternal(activeSystem, moduleScript)
-				Systems[moduleScript.Name] = activeSystem
-				moduleScript.Name = HttpService:GenerateGUID()
+				Systems[moduleScript] = activeSystem
 			end
 			pending -= 1
 		end)
@@ -284,7 +283,7 @@ function Galaxy.Launch(launchParams: LaunchParams)
 	-- Require every system in parallel and wait for the whole batch before running any lifecycle hooks.
 	_loadSystems(systemModules)
 
-	for name, system in Systems do
+	for moduleScript, system in Systems do
 		if typeof(system.onInit) ~= "function" then
 			continue
 		end
@@ -295,7 +294,7 @@ function Galaxy.Launch(launchParams: LaunchParams)
 
 		if coroutine.status(initThread) == "suspended" then
 			warn(
-				`⏳ [Galaxy][IMPORTANT] {name}.onInit yielded, continuing without waiting for it. Move WaitForChild / :Wait() / network calls into onStart so init order stays deterministic.`
+				`⏳ [Galaxy][IMPORTANT] {moduleScript:GetFullName()}.onInit yielded, continuing without waiting for it. Move WaitForChild / :Wait() / network calls into onStart so init order stays deterministic.`
 			)
 		end
 	end

--- a/src/init.luau
+++ b/src/init.luau
@@ -8,7 +8,7 @@
     • ⚡ Optimized for performance
     • 🛡️ Type-safe with Luau
     
-    Version: 1.0.1
+    Version: 1.1.0
     Author: ArtisticVampyre
 	Contributor: @32_Bits (https://github.com/git0uttahere)
 --]]

--- a/src/init.luau
+++ b/src/init.luau
@@ -59,14 +59,7 @@ local function _safeRequire(module: ModuleScript, label: string): (boolean, any)
 	local completed = false
 	task.delay(INIT_YIELD_WARNING_TIME, function()
 		if not completed then
-			warn(
-				(`⏳ [Galaxy][IMPORTANT] requiring %s '%s' has been yielding for %ds+. `
-					.. `A top-level WaitForChild/:Wait()/yield during require blocks the whole boot — move it into onInit/onStart.`):format(
-					label,
-					module.Name,
-					INIT_YIELD_WARNING_TIME
-				)
-			)
+			warn(`⏳[Galaxy][IMPORTANT] requiring {label} {module.Name} has been yielding for {INIT_YIELD_WARNING_TIME}s+. A top-level WaitForChild/:Wait()/yield during require blocks the whole boot, move it into onStart.`)
 		end
 	end)
 
@@ -117,12 +110,7 @@ local function _load(module: ModuleScript): any?
 		return dataOrErr
 	end
 
-	warn(
-		(`❌ [Galaxy][CRITICAL] Failed to require module '%s' (skipped — other modules still load):\n%s`):format(
-			module.Name,
-			dataOrErr
-		)
-	)
+	warn(`❌ [Galaxy][CRITICAL] Failed to require module {module.Name} (skipped — other modules still load):\n{dataOrErr}`)
 	return nil
 end
 
@@ -183,7 +171,7 @@ local function _loadInternal(system, rootModule: ModuleScript)
 	for _, dirKey: string in internal do
 		local dir: Folder? = root:FindFirstChild(dirKey) :: Folder?
 		if not dir then
-			warn(("❗️Internal directory '%s' not found in system '%s'! 🚫"):format(dirKey, root.Name))
+			warn(`❗️Internal directory {dirKey} not found in system {root.Name}! 🚫`)
 			continue
 		end
 
@@ -194,13 +182,7 @@ local function _loadInternal(system, rootModule: ModuleScript)
 
 			local success, dataOrErr = _safeRequire(module, "internal module")
 			if not success then
-				warn(
-					("❌ [Galaxy] Failed to load internal module '%s' in system '%s' (skipped)! 💥\nError: %s"):format(
-						module.Name,
-						root.Name,
-						dataOrErr
-					)
-				)
+				warn(`❌ [Galaxy] Failed to load internal module {module.Name} in system {root.Name} (skipped)! 💥\nError: {dataOrErr}`)
 				continue
 			end
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -8,7 +8,7 @@
     • ⚡ Optimized for performance
     • 🛡️ Type-safe with Luau
     
-    Version: 1.1.0
+    Version: 1.2.0
     Author: ArtisticVampyre
 	Contributor: @32_Bits (https://github.com/git0uttahere)
 --]]
@@ -28,7 +28,7 @@ type LaunchParams = {
 }
 
 -- 🌟 Main Module
-local Galaxy = { _VERSION = "1.1.0" }
+local Galaxy = { _VERSION = "1.2.0" }
 
 -- 🎯 Environment Detection
 local SystemKey: string = RunService:IsServer() and "service" or "controller"

--- a/src/wally.toml
+++ b/src/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artisticvampyre/galaxy"
-version = "1.1.0"
+version = "1.2.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 

--- a/src/wally.toml
+++ b/src/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "artisticvampyre/galaxy"
-version = "1.0.0"
+version = "1.1.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
## Summary

- Bump Galaxy to **1.2.1** (`init.luau`, `wally.toml`).
- Load systems in parallel: all system modules are required together, then `onInit` runs in parallel across systems, with `onStart` deferred until every `onInit` has settled.
- Add a yield watchdog that warns when a module require or `onInit` blocks boot for longer than 3 seconds (e.g. top-level `WaitForChild` / `:Wait()`).
- Stop renaming system `ModuleScript`s to GUIDs on load; key the internal `Systems` table by `ModuleScript` instead of name.
- Expand README with installation, getting started, and framework reference docs.
